### PR TITLE
Make clusterrolebinding respect to namespace option when installing helm

### DIFF
--- a/apigw-ingress-controller-blog/AmazonAPIGWHelmChart/amazon-apigateway-ingress-controller/templates/clusterrolebinding.yaml
+++ b/apigw-ingress-controller-blog/AmazonAPIGWHelmChart/amazon-apigateway-ingress-controller/templates/clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ .Release.Name }}-amzn-apigw-ingress-controller
-  namespace: default
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Pod wasn't able to list ingresses because clusterrolebinding creating in default namespace other then specified with `-n` option in helm.